### PR TITLE
Add devmesh sidecar injection annotation

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: adservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: adservice
       terminationGracePeriodSeconds: 5

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: cartservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: cartservice
       terminationGracePeriodSeconds: 5

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: checkoutservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: checkoutservice
       securityContext:

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: currencyservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: currencyservice
       terminationGracePeriodSeconds: 5

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: emailservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: emailservice
       terminationGracePeriodSeconds: 5

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -28,6 +28,7 @@ spec:
         app: frontend
       annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: frontend
       securityContext:

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: paymentservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: paymentservice
       terminationGracePeriodSeconds: 5

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: productcatalogservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: productcatalogservice
       terminationGracePeriodSeconds: 5

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: recommendationservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: recommendationservice
       terminationGracePeriodSeconds: 5

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       labels:
         app: shippingservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: shippingservice
       securityContext:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -32,6 +32,8 @@ spec:
     metadata:
       labels:
         app: currencyservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: currencyservice
       terminationGracePeriodSeconds: 5
@@ -193,6 +195,8 @@ spec:
     metadata:
       labels:
         app: productcatalogservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: productcatalogservice
       terminationGracePeriodSeconds: 5
@@ -266,6 +270,8 @@ spec:
     metadata:
       labels:
         app: checkoutservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: checkoutservice
       securityContext:
@@ -348,6 +354,8 @@ spec:
     metadata:
       labels:
         app: shippingservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: shippingservice
       securityContext:
@@ -421,6 +429,8 @@ spec:
     metadata:
       labels:
         app: cartservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: cartservice
       terminationGracePeriodSeconds: 5
@@ -564,6 +574,8 @@ spec:
     metadata:
       labels:
         app: emailservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: emailservice
       terminationGracePeriodSeconds: 5
@@ -639,6 +651,8 @@ spec:
     metadata:
       labels:
         app: paymentservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: paymentservice
       terminationGracePeriodSeconds: 5
@@ -714,6 +728,7 @@ spec:
         app: frontend
       annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: frontend
       securityContext:
@@ -840,6 +855,8 @@ spec:
     metadata:
       labels:
         app: recommendationservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: recommendationservice
       terminationGracePeriodSeconds: 5
@@ -917,6 +934,8 @@ spec:
     metadata:
       labels:
         app: adservice
+      annotations:
+        sidecar.signadot.com/inject: "true"
     spec:
       serviceAccountName: adservice
       terminationGracePeriodSeconds: 5


### PR DESCRIPTION
## Summary
- Add `sidecar.signadot.com/inject: "true"` pod annotation to all 10 application service deployments (adservice, cartservice, checkoutservice, currencyservice, emailservice, frontend, paymentservice, productcatalogservice, recommendationservice, shippingservice)
- Excludes loadgenerator and redis-cart, matching the staging cluster setup
- Updated both `kubernetes-manifests/` and `release/kubernetes-manifests.yaml`

## Test plan
- [x] Verified annotation works on prod cluster (`demo-eks-api.tail473aa.ts.net`) — all pods running 2/2 with sd-sidecar
- [x] Confirmed request propagation via sd-sidecar logs (`routedTo: "baseline"`)
- [x] Matches staging cluster (`staging-eks-api.tail473aa.ts.net`) configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)